### PR TITLE
Fixes issue #34 (Now correctly handles immutable objects when hideRoot is false)

### DIFF
--- a/src/JSONIterableNode.js
+++ b/src/JSONIterableNode.js
@@ -25,7 +25,7 @@ function renderItemString({
 
 // Returns the child nodes for each entry in iterable.
 // If we have generated them previously we return from cache; otherwise we create them.
-function getChildNodes({
+export function getChildNodes({
   data,
   getItemString,
   labelRenderer,

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@
 
 import React from 'react';
 import grabNode from './grab-node';
+import objType from './obj-type';
 import solarized from './themes/solarized';
-import {getChildNodes} from './JSONObjectNode';
+import { getChildNodes as getObjectChildNodes } from './JSONObjectNode';
+import { getChildNodes as getIterableChildNodes } from './JSONIterableNode';
 
 const styles = {
   tree: {
@@ -77,6 +79,7 @@ export default class JSONTree extends React.Component {
     } = this.props;
 
     let nodeToRender;
+    let getChildNodes = objType(value) === 'Iterable' ? getIterableChildNodes : getObjectChildNodes;
 
     if (!this.props.hideRoot) {
       nodeToRender = grabNode({


### PR DESCRIPTION
Don't know if this is the best way to go about it, but a fairly simple fix which doesn't break hiding root node when using immutable library.