### PR TITLE
add the key path as an argument to the value renderer

### DIFF
--- a/src/JSONValueNode.js
+++ b/src/JSONValueNode.js
@@ -20,7 +20,7 @@ const JSONValueNode = ({
       {labelRenderer(...keyPath)}:
     </label>
     <span {...styling('valueText', nodeType, keyPath)}>
-      {valueRenderer(valueGetter(value), value)}
+      {valueRenderer(valueGetter(value), value, ...keyPath)}
     </span>
   </li>
 );


### PR DESCRIPTION
Adding the key path to the value renderer allows contextual rendering based on the current key or path.

This would be very helpful for https://github.com/thebakeryio/meteor-devtools/issues/46.