### PR TITLE
fix bug for hideRoot=true and shouldExpandNode is false

### DIFF
--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -115,7 +115,7 @@ export default class JSONNestedNode extends React.Component {
       expandable
     } = this.props;
     const expanded = this.state.expanded;
-    const renderedChildren = expanded ?
+    const renderedChildren = expanded || (hideRoot && this.props.level === 0) ?
       renderChildNodes({ ...this.props, level: this.props.level + 1 }) : null;
 
     const itemType = (


### PR DESCRIPTION
This fixes a bug when ```hideRoot = true``` and ```shouldExpandNode``` is false at level 0, the tree is completely hidden since the children at level 1 are hidden.