### PR TITLE
Adds notification handler for node expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ For `labelRenderer`, you can provide a full path - [see this PR](https://github.
 - `shouldExpandNode: function(keyName, data, level)` - determines if node should be expanded (root is expanded by default)
 - `hideRoot: Boolean` - if `true`, the root node is hidden.
 - `sortObjectKeys: Boolean | function(a, b)` - sorts object keys with compare function (optional). Isn't applied to iterable maps like `Immutable.Map`.
+- `onNodeExpansionChanged: function(keyName, data, level, expanded)` - invoked when a node is expanded or collapsed.
 
 ### Credits
 

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -158,6 +158,19 @@ const App = () => (
         shouldExpandNode={() => false}
       />
     </div>
+    <p>Expansion Notifications</p>
+    <div>
+      <JSONTree
+        data={data}
+        theme={theme}
+        shouldExpandNode={() => false}
+        onNodeExpansionChanged={
+          (keyPath, data, level, expanded) => {
+            console.log(`Node ${expanded ? 'expanded' : 'collapsed'}: ${keyPath}`);
+          }
+        }
+      />
+    </div>
   </div>
 );
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "author": "Shu Uesugi <shu@chibicode.com> (http://github.com/chibicode)",
   "contributors": [
     "Dave Vedder <veddermatic@gmail.com> (http://www.eskimospy.com/)",
-    "Daniele Zannotti <dzannotti@me.com> (http://www.github.com/dzannotti)"
+    "Daniele Zannotti <dzannotti@me.com> (http://www.github.com/dzannotti)",
+    "Phillip Hoff <phillip@orst.edu> (http://www.github.com/philliphoff)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -76,7 +76,8 @@ export default class JSONNestedNode extends React.Component {
     level: PropTypes.number.isRequired,
     sortObjectKeys: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     isCircular: PropTypes.bool,
-    expandable: PropTypes.bool
+    expandable: PropTypes.bool,
+    onNodeExpansionChanged: PropTypes.func
   };
 
   static defaultProps = {
@@ -166,5 +167,17 @@ export default class JSONNestedNode extends React.Component {
     );
   }
 
-  handleClick = () => this.setState({ expanded: !this.state.expanded });
+  handleClick = () => {
+    this.setState(
+      { expanded: !this.state.expanded },
+      () => {
+        if (this.props.onNodeExpansionChanged) {
+          this.props.onNodeExpansionChanged(
+            this.props.keyPath,
+            this.props.data,
+            this.props.level,
+            this.state.expanded);
+        }
+      });
+  }
 }


### PR DESCRIPTION
Adds the optional property `onNodeExpansionChanged(keyName, data, level, expanded)` to `JSONNestedNode`.  This allows applications to be notified when a node is expanded or collapsed.  This can be used, for example, in conjunction with `shouldExpandNode` to preserve the expansion state of the JSON tree across views.