### PR TITLE
Support for ES6 Map

### DIFF
--- a/src/getCollectionEntries.js
+++ b/src/getCollectionEntries.js
@@ -44,7 +44,7 @@ function getEntries(type, collection, sortObjectKeys, from=0, to=Infinity) {
         break;
       } if (from <= idx) {
         if (isMap && Array.isArray(item)) {
-          entries.push({ key: item[0], value: item[1] });
+          entries.push({ key: idx, value: [item[0], item[1]] });
         } else {
           entries.push({ key: idx, value: item });
         }

--- a/src/getCollectionEntries.js
+++ b/src/getCollectionEntries.js
@@ -44,7 +44,7 @@ function getEntries(type, collection, sortObjectKeys, from=0, to=Infinity) {
         break;
       } if (from <= idx) {
         if (isMap && Array.isArray(item)) {
-          entries.push({ key: idx, value: [item[0], item[1]] });
+          entries.push({ key: idx, value: { key: item[0], value: item[1] } });
         } else {
           entries.push({ key: idx, value: item });
         }


### PR DESCRIPTION
The current implementation supports only object-like maps. The problem is that we can have any data type as a map key.

So, the following example would just throw:
```js
new Map([
  ['a', 1],
  [{toString: function(){ return 'a' }}, 2],
  [{}, 3]
])
```

While with this pr, it will show the following:
<img width="296" alt="screen shot 2017-02-16 at 8 39 39 pm" src="https://cloud.githubusercontent.com/assets/7957859/23035702/ba4716aa-f488-11e6-8319-69a0d16b9d6c.png">

Showing maps as an array of tuples was suggested in [a productpains ticket](https://productpains.com/post/redux-devtools-extension/expand-iterables).