### PR TITLE
Remove babel runtime dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["transform-decorators-legacy", "transform-runtime", "transform-es3-property-literals", "transform-es3-member-expression-literals"],
+  "plugins": ["transform-decorators-legacy", "transform-es3-property-literals", "transform-es3-member-expression-literals"],
   "presets": ["es2015-loose", "stage-0", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
-    "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.5.0",
@@ -65,7 +64,6 @@
     "react-dom": "^15.0.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1",
     "react-base16-styling": "^0.4.1",
     "react-pure-render": "^1.0.2"
   },

--- a/src/objType.js
+++ b/src/objType.js
@@ -1,7 +1,9 @@
 export default function objType(obj) {
   const type = Object.prototype.toString.call(obj).slice(8, -1);
-  if (type === 'Object' && typeof obj[Symbol.iterator] === 'function') {
-    return 'Iterable';
+  if (type === 'Object') {
+    try {
+      if (typeof obj.forEach === 'function') return 'Iterable';
+    } catch (e) { /* Don't throw */ }
   }
 
   return type;

--- a/test/objType.spec.js
+++ b/test/objType.spec.js
@@ -1,0 +1,23 @@
+import expect from 'expect';
+
+import objType from '../src/objType';
+
+describe('objType', () => {
+  it('should determine the correct type', () => {
+    expect(objType({})).toBe('Object');
+    expect(objType([])).toBe('Array');
+    expect(objType(new Map())).toBe('Map');
+    expect(objType(new WeakMap())).toBe('WeakMap');
+    expect(objType(new Set())).toBe('Set');
+    expect(objType(new WeakSet())).toBe('WeakSet');
+    expect(objType(new Error())).toBe('Error');
+    expect(objType(new Date())).toBe('Date');
+    expect(objType(() => {})).toBe('Function');
+    expect(objType('')).toBe('String');
+    expect(objType(true)).toBe('Boolean');
+    expect(objType(null)).toBe('Null');
+    expect(objType(undefined)).toBe('Undefined');
+    expect(objType(10)).toBe('Number');
+    expect(objType(Symbol.iterator)).toBe('Symbol');
+  });
+});


### PR DESCRIPTION
This PR removes the usage of `Symbol.iterator` in order to remove `babel-runtime` while (hopefully 😄) still supporting IE11.

This reduces the package size from 2.3 MB down to only 300 kB.

The PR relies on the fact that iterable objects should have a `.forEach` method. At least that's my intuition, though I'm not an expert on this particular subject.

I added tests for the types mentioned in [`JSONNode.js`](https://github.com/alexkuz/react-json-tree/blob/master/src/JSONNode.js#L38) though I couldn't come up with test cases for type `Custom` and `Iterable`.