### PR TITLE
omitted valueGetterFor Number nodetype (numeric values )

### DIFF
--- a/src/JSONNode.js
+++ b/src/JSONNode.js
@@ -46,7 +46,7 @@ const JSONNode = ({
     case 'Iterable':
     case 'Map':
     case 'Set':
-      return <JSONIterableNode {...nestedNodeProps} />;
+      return <JSONIterableNode {...nestedNodeProps} valueGetter={raw => `"${raw}"`}/>;
     case 'String':
       return <JSONValueNode {...simpleNodeProps} valueGetter={raw => `"${raw}"`} />;
     case 'Number':


### PR DESCRIPTION
Node items with numeric value are not rendered as the valueGetter function is not defined. This PR fix this issue by assigning a valueGetter  function to nodetype of value "Number"