### PR TITLE
Replaced ES6 instance methods with static one

### DIFF
--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -110,7 +110,7 @@ export default class JSONNestedNode extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !!Object.keys(nextProps).find(key =>
+    return !!Array.find(Object.keys(nextProps), key =>
       key !== 'circularCache' &&
       (key === 'keyPath' ?
         nextProps[key].join('/') !== this.props[key].join('/') :

--- a/src/index.js
+++ b/src/index.js
@@ -109,13 +109,13 @@ export default class JSONTree extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (['theme', 'invertTheme'].find(k => nextProps[k] !== this.props[k])) {
+    if (Array.find(['theme', 'invertTheme'], k => nextProps[k] !== this.props[k])) {
       this.setState(getStateFromProps(nextProps));
     }
   }
 
   shouldComponentUpdate(nextProps) {
-    return !!Object.keys(nextProps).find(k => (
+    return !!Array.find(Object.keys(nextProps), k => (
       k === 'keyPath' ?
         nextProps[k].join('/') !== this.props[k].join('/') :
         nextProps[k] !== this.props[k]


### PR DESCRIPTION
#### What is done in this PR

- Replaced ES6 insance methods `Array.prototype.find` with `Array.find` as `babel-plugin-transform-runtime` does not polyfill them in such a way (see [why](https://babeljs.io/docs/plugins/transform-runtime/#why-) and also see readme from [core-js, without global scope pollution](https://github.com/zloirock/core-js)).

Currently `react-json-tree` doesn't work on IE and Edge 11, see [MDN](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/find)

@alexkuz please consider this changes.