### PR TITLE
Fix function object’s prototype with toStringTag.

### DIFF
--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -30,7 +30,14 @@ const getValueLabelStyle = ({ style }, nodeType, keyPath) => ({
 // eslint-disable-next-line max-len
 const longString = 'Loremipsumdolorsitamet,consecteturadipiscingelit.Namtempusipsumutfelisdignissimauctor.Maecenasodiolectus,finibusegetultricesvel,aliquamutelit.Loremipsumdolorsitamet,consecteturadipiscingelit.Namtempusipsumutfelisdignissimauctor.Maecenasodiolectus,finibusegetultricesvel,aliquamutelit.Loremipsumdolorsitamet,consecteturadipiscingelit.Namtempusipsumutfelisdignissimauctor.Maecenasodiolectus,finibusegetultricesvel,aliquamutelit.';
 
+var Custom = function(value) { this.value = value; };
+Custom.prototype[Symbol.toStringTag] = 'Custom';
+
 const data = {
+  profile: {
+    avatar: new Custom('placehold.it/50x50'),
+    name: new Custom('Name'),
+  },
   array: [1, 2, 3],
   emptyArray: [],
   bool: true,
@@ -180,4 +187,3 @@ const App = () => (
 );
 
 export default App;
-

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -34,10 +34,6 @@ var Custom = function(value) { this.value = value; };
 Custom.prototype[Symbol.toStringTag] = 'Custom';
 
 const data = {
-  profile: {
-    avatar: new Custom('placehold.it/50x50'),
-    name: new Custom('Name'),
-  },
   array: [1, 2, 3],
   emptyArray: [],
   bool: true,
@@ -79,6 +75,10 @@ const data = {
     { objectKey: 'value2' }
   ]),
   hugeArray: Array.from({ length: 10000 }).map((_, i) => `item #${i}`),
+  customProfile: {
+    avatar: new Custom('placehold.it/50x50'),
+    name: new Custom('Name'),
+  },
   longString
 };
 

--- a/src/JSONNode.js
+++ b/src/JSONNode.js
@@ -6,13 +6,6 @@ import JSONArrayNode from './JSONArrayNode';
 import JSONIterableNode from './JSONIterableNode';
 import JSONValueNode from './JSONValueNode';
 
-function convertCustomType(value, type) {
-  if (type === 'Custom' && value.constructor !== Object && value instanceof Object) {
-    return 'Object';
-  }
-  return type;
-}
-
 const JSONNode = ({
   getItemString,
   keyPath,
@@ -23,7 +16,7 @@ const JSONNode = ({
   isCustomNode,
   ...rest
 }) => {
-  const nodeType = isCustomNode(value) ? 'Custom' : convertCustomType(value, objType(value));
+  const nodeType = isCustomNode(value) ? 'Custom' : objType(value);
 
   const simpleNodeProps = {
     getItemString,
@@ -88,3 +81,4 @@ JSONNode.propTypes = {
 };
 
 export default JSONNode;
+

--- a/src/JSONNode.js
+++ b/src/JSONNode.js
@@ -6,6 +6,13 @@ import JSONArrayNode from './JSONArrayNode';
 import JSONIterableNode from './JSONIterableNode';
 import JSONValueNode from './JSONValueNode';
 
+function convertCustomType(value, type) {
+  if (type === 'Custom' && value.constructor !== Object && value instanceof Object) {
+    return 'Object';
+  }
+  return type;
+}
+
 const JSONNode = ({
   getItemString,
   keyPath,
@@ -16,7 +23,7 @@ const JSONNode = ({
   isCustomNode,
   ...rest
 }) => {
-  const nodeType = isCustomNode(value) ? 'Custom' : objType(value);
+  const nodeType = isCustomNode(value) ? 'Custom' : convertCustomType(value, objType(value));
 
   const simpleNodeProps = {
     getItemString,
@@ -81,4 +88,3 @@ JSONNode.propTypes = {
 };
 
 export default JSONNode;
-

--- a/src/objType.js
+++ b/src/objType.js
@@ -4,5 +4,10 @@ export default function objType(obj) {
     return 'Iterable';
   }
 
+  if (type === 'Custom' && obj.constructor !== Object && obj instanceof Object) {
+    // For projects implementing objects overriding `.prototype[Symbol.toStringTag]`
+    return 'Object';
+  }
+
   return type;
 }


### PR DESCRIPTION
Some projects are implementing objects overriding `.prototype[Symbol.toStringTag]` for better read
in .toString output and "emulate" something fancy like a typed system in javascript. (example project: https://github.com/origamitower/folktale)

Unfortunately, it'll crash this project since it treat non recognized types as "Custom" and current representation is JsonValue.

My patch just check for this case and use object representation instead.

btw, I don't know if it's the best solution for this problem.