### PR TITLE
add RJV link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ For `labelRenderer`, you can provide a full path - [see this PR](https://github.
 - [react-treeview](https://github.com/chenglou/react-treeview)
 - [react-json-inspector](https://github.com/Lapple/react-json-inspector)
 - [react-object-inspector](https://github.com/xyc/react-object-inspector)
+- [react-json-view](https://github.com/mac-s-g/react-json-view)
 
 ### License
 


### PR DESCRIPTION
Thanks for putting together an awesome component!
it would be really cool if you guys linked to my project in the "similar libraries" portion of your readme.  
my project is: https://github.com/mac-s-g/react-json-view
I'm currently working on building out some comprehensive built-in CRUD support for interacting with javascript objects.
I used a lot of design ideas found here when building my component.  I really like your base-16 theme integration!
I also linked your project in my readme: https://github.com/mac-s-g/react-json-view#inspiration

thanks again!