### PR TITLE
prevents #94 (warnings under react 16) 

### DIFF
--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -168,13 +168,13 @@ export default class JSONNestedNode extends React.Component {
         }
         <label
           {...styling(['label', 'nestedNodeLabel'], ...stylingArgs)}
-          onClick={expandable && this.handleClick}
+          onClick={expandable ? this.handleClick : undefined}
         >
           {labelRenderer(...stylingArgs)}
         </label>
         <span
           {...styling('nestedNodeItemString', ...stylingArgs)}
-          onClick={expandable && this.handleClick}
+          onClick={expandable ? this.handleClick : undefined}
         >
           {renderedItemString}
         </span>


### PR DESCRIPTION
JSONNestedNode does this:

```
        <span
          {...styling('nestedNodeItemString', ...stylingArgs)}
          onClick={expandable && this.handleClick}
        >
```
... which causes React 16 to log warnings about setting a boolean to onClick.

Returning undefined instead of false resolves the issue.

