### PR TITLE
Fix #83: Support for boolean sortObjectKeys prop

### DIFF
--- a/src/getCollectionEntries.js
+++ b/src/getCollectionEntries.js
@@ -18,8 +18,15 @@ function getEntries(type, collection, sortObjectKeys, from = 0, to = Infinity) {
   if (type === 'Object') {
     let keys = Object.getOwnPropertyNames(collection);
 
-    if (typeof sortObjectKeys !== 'undefined') {
-      keys.sort(sortObjectKeys);
+    switch (typeof sortObjectKeys) {
+      case 'boolean':
+        keys.sort();
+        break;
+      case 'function':
+        keys.sort(sortObjectKeys);
+        break;
+      default:
+      // Do nothing
     }
 
     keys = keys.slice(from, to + 1);


### PR DESCRIPTION
Documentation suggests that passing a boolean to the `sortObjectKeys` prop should provide a default sorting method. This commit adds a type check to support both boolean and comparator functions.

Otherwise, invoking `array.sort(true)` yields:

> TypeError: invalid Array.prototype.sort argument[

---

Fixes https://github.com/alexkuz/react-json-tree/issues/83