### PR TITLE
Show unknown nodes

### DIFF
--- a/src/JSONNode.js
+++ b/src/JSONNode.js
@@ -85,7 +85,9 @@ const JSONNode = ({
     case 'Custom':
       return <JSONValueNode {...simpleNodeProps} />;
     default:
-      return null;
+      return (
+        <JSONValueNode {...simpleNodeProps} valueGetter={raw => `<${nodeType}>`} />
+      );
   }
 };
 


### PR DESCRIPTION
Currently objects of unknown types are simply hidden, which can be
confusing as it would show, for example, “1 key”, but then not show any
keys.

This PR fixes that by showing a placeholder with the name of the class.
E.g. `<Int8Array>`.